### PR TITLE
feat: Support Firmware 2.7.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,7 @@ The proxy uses a factory pattern to support multiple interface types:
 
 ### Python Dependencies
 
-- meshtastic==2.7.5
+- meshtastic==2.7.7
 - paho-mqtt==2.1.0
 - pubsub==4.0.7
 - protobuf>=3.20.0,<6.0.0
@@ -418,8 +418,8 @@ Users should be aware that the Docker image built from this repository bundles s
 ---
 
 **Status**: Production Ready ✅  
-**Version**: 1.0.3
-**Last Updated**: 2026-01-17
+**Version**: 1.0.4
+**Last Updated**: 2026-01-25
 
 
 This application was developed with Antigravity and the help of Gemini

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # Pinned versions for reproducible builds
 
 # Meshtastic Python library
-meshtastic==2.7.5
+meshtastic==2.7.7
 
 # MQTT client
 paho-mqtt==2.1.0


### PR DESCRIPTION
Updates meshtastic dependency to 2.7.7 and bumps version to 1.0.4 to ensure compatibility with Firmware 2.7.18.