### PR TITLE
Release v1.2.0

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -15,7 +15,7 @@ jobs:
         uses: snok/container-retention-policy@v3.0.0
         with:
           image-names: mqtt-proxy
-          cut-off: 14 days ago UTC
+          cut-off: 14d
           account: user
           token: ${{ secrets.GITHUB_TOKEN }}
           tag-selection: untagged
@@ -24,7 +24,7 @@ jobs:
         uses: snok/container-retention-policy@v3.0.0
         with:
           image-names: mqtt-proxy
-          cut-off: 14 days ago UTC
+          cut-off: 14d
           account: user
           token: ${{ secrets.GITHUB_TOKEN }}
           image-tags: fix-*,feat-*,pr-*
@@ -34,7 +34,7 @@ jobs:
         uses: snok/container-retention-policy@v3.0.0
         with:
           image-names: mqtt-proxy
-          cut-off: 30 days ago UTC
+          cut-off: 30d
           account: user
           token: ${{ secrets.GITHUB_TOKEN }}
           image-tags: master

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,110 @@
+# Release v1.2.0
+
+## 🛡️ Reliability & Stability Improvements
+
+### Thread-Safe Radio Interactions
+- **Locked Radio Access**: Implemented thread-safe `_sendToRadio` using the interface's internal locking mechanism.
+  - Prevents potential race conditions when multiple handlers attempt to send data to the radio simultaneously.
+  - Added fallback with warning if `_sendToRadio` is missing (e.g., in older `meshtastic` library versions).
+
+### Enhanced Packet Management
+- **Improved Deduplication**: Refined the deduplication logic to better handle packet IDs and sender tracking.
+  - Prevents message loops when proxying traffic between MQTT and the mesh network.
+
+### Robust Health Monitoring
+- **Configuration Race Condition Fix**: Addressed a race condition in MQTT handler initialization to ensure reliable startup and state management.
+- **Improved Health Checks**: Enhanced watchdog mechanisms for better reporting of proxy status.
+
+## 📊 Performance & Monitoring
+
+### Latency Logging
+- **Detailed Message Queue Stats**: Added precise timing logs for message processing.
+  - New Log Format: `Message processed. Queue: N msgs, Wait: X.XXXs, Send: X.XXXs`
+  - Helps track transit times and identify bottlenecks in radio transmissions.
+
+## 🧪 Test Coverage & CI/CD
+
+### Enhanced Test Suite
+- **Queue Handler Coverage**: Increased test coverage for `handlers/queue.py` to ensure reliable buffering and rate limiting.
+- **Thread Safety Validation**: Added tests to verify thread-safe usage of the radio interface.
+
+### CI/CD Optimizations
+- **Build Trigger Cleanup**: Fixed duplicate Docker image builds by refining push event wildcard triggers.
+- **Cleanup Workflow Fix**: Resolved `Invalid Cut-off` errors in image retention policy by updating to properly formatted duration strings (`14d`).
+
+## 🔄 Breaking Changes
+None - all changes are backward compatible.
+
+## 📊 Testing Status
+All tests passing with improved coverage in core message handling modules.
+
+---
+
+**Full Changelog**: https://github.com/LN4CY/mqtt-proxy/compare/v1.1.2...v1.2.0
+
+# Release v1.1.2
+
+## 🚀 Performance & Reliability Improvements
+
+### Major Performance Enhancement
+- **50x faster MQTT-to-node forwarding**: Reduced default `MESH_TRANSMIT_DELAY` from 500ms to 10ms
+  - Typical transmission is ~1ms, 10ms provides safe spacing while maintaining responsiveness
+  - Configurable via `MESH_TRANSMIT_DELAY` environment variable
+  
+### Retained Message Filtering  
+- **Prevents startup floods**: Skip retained MQTT messages by default
+  - Eliminates 4+ second queue backlogs when connecting to broker
+  - Retained messages are historical state, not live mesh traffic
+  - Opt-in via `MQTT_FORWARD_RETAINED=true` if needed
+
+### Enhanced Monitoring
+- **Queue depth logging**: Added current queue size to message processing logs
+  - Format: `Queue: N msgs, Wait: X.XXXs, Send: X.XXXs`
+  - Helps identify backlogs and performance issues
+
+## 🧪 Test Coverage Improvements
+
+### Comprehensive Test Suite
+- **40 tests → 42 tests**: Added extensive coverage for critical paths
+- **87% total coverage** across all handlers
+  - `handlers/mqtt.py`: 90% coverage
+  - `handlers/meshtastic.py`: 77% coverage  
+  - `handlers/node_tracker.py`: 86% coverage
+  - `handlers/queue.py`: 92% coverage
+
+### New Test Files
+- `test_mqtt_extended.py`: TLS configuration, error handling, edge cases
+- `test_meshtastic_extended.py`: Byte parsing, implicit ACKs, DecodeError handling
+- `test_proxy_health.py`: Health checks, watchdog mechanisms, state management
+- `test_retained_messages.py`: Retained message filtering validation
+
+## 🐛 Bug Fixes
+
+- **Critical**: Fixed `fromId` AttributeError in packet tracking
+  - MeshPacket protobuf only has `from` field, not `fromId`
+  - Was causing "Failed to track node/packet: fromId" errors
+  
+- **CI/CD**: Fixed module import errors in GitHub Actions
+  - Added `sys.path.append()` to test files for proper module resolution
+
+- **Pytest**: Renamed `TestInterface` to `MixinTestHelper`
+  - Eliminates pytest warning about test classes with `__init__` constructors
+
+## 📝 Configuration
+
+### New Environment Variables
+- `MESH_TRANSMIT_DELAY`: Delay between messages (default: `0.01` seconds)
+- `MQTT_FORWARD_RETAINED`: Forward retained messages (default: `false`)
+
+## 🔄 Breaking Changes
+None - all changes are backward compatible
+
+## 📊 Testing
+All 42 tests passing with 87% coverage across handlers
+
+## 🙏 Contributors
+Thank you to everyone who helped test and validate these improvements!
+
+---
+
+**Full Changelog**: https://github.com/LN4CY/mqtt-proxy/compare/v1.1.1...v1.1.2

--- a/health_fail.txt
+++ b/health_fail.txt
@@ -1,0 +1,189 @@
+============================= test session starts =============================
+platform win32 -- Python 3.14.2, pytest-7.4.3, pluggy-1.6.0 -- C:\Users\dremb\AppData\Local\Python\pythoncore-3.14-64\python.exe
+cachedir: .pytest_cache
+rootdir: E:\proj\AiAssited\mqtt-proxy
+plugins: anyio-3.7.1, cov-4.1.0
+collecting ... collected 7 items
+
+tests/test_proxy_health.py::test_proxy_init PASSED                       [ 14%]
+tests/test_proxy_health.py::test_on_connection_edge_cases FAILED         [ 28%]
+tests/test_proxy_health.py::test_on_connection_lost_debounce PASSED      [ 42%]
+tests/test_proxy_health.py::test_health_check_logic FAILED               [ 57%]
+tests/test_proxy_health.py::test_log_status FAILED                       [ 71%]
+tests/test_proxy_health.py::test_update_heartbeat FAILED                 [ 85%]
+tests/test_proxy_health.py::test_cleanup PASSED                          [100%]
+
+================================== FAILURES ===================================
+________________________ test_on_connection_edge_cases ________________________
+
+    def test_on_connection_edge_cases():
+        proxy = MQTTProxy()
+    
+        # CASE: No localNode
+        iface = MagicMock()
+        iface.localNode = None
+        proxy.on_connection(iface)
+        assert proxy.last_radio_activity == 0
+    
+        # CASE: Exception in node ID
+        node = MagicMock()
+        iface.localNode = node
+        type(node).nodeNum = property(lambda x: 1/0) # Trigger exception
+        proxy.on_connection(iface)
+        # Should handle gracefully
+    
+        # CASE: No MQTT config
+        node = MagicMock()
+        iface.localNode = node
+        node.nodeNum = 12345
+        # Ensure moduleConfig exists but .mqtt is explicitly Falsey
+        node.moduleConfig = MagicMock()
+        node.moduleConfig.mqtt = None
+    
+        proxy.on_connection(iface)
+>       assert proxy.mqtt_handler is None
+E       assert <handlers.mqtt.MQTTHandler object at 0x000001C7B5E66510> is None
+E        +  where <handlers.mqtt.MQTTHandler object at 0x000001C7B5E66510> = <mqtt_proxy_test.MQTTProxy object at 0x000001C7B56E4550>.mqtt_handler
+
+tests\test_proxy_health.py:55: AssertionError
+------------------------------ Captured log call ------------------------------
+WARNING  mqtt-proxy:mqtt-proxy.py:107 No localNode available
+ERROR    mqtt-proxy.handlers.mqtt:mqtt.py:108 Failed to connect to MQTT broker: Invalid host.
+WARNING  mqtt-proxy:mqtt-proxy.py:131 No MQTT configuration found on node!
+___________________________ test_health_check_logic ___________________________
+
+    def test_health_check_logic():
+        proxy = MQTTProxy()
+        proxy.connection_lost_time = 0
+        proxy.last_radio_activity = time.time() # Ensure it's not silent
+    
+        # 1. OK State
+        ok, reasons = proxy._perform_health_check(time.time())
+        assert ok == True
+    
+        # 2. MQTT Disconnected
+        proxy.mqtt_handler = MagicMock()
+        proxy.mqtt_handler.health_check_enabled = True
+        proxy.mqtt_handler.connected = False
+>       ok, reasons = proxy._perform_health_check(time.time())
+
+tests\test_proxy_health.py:80: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+self = <mqtt_proxy_test.MQTTProxy object at 0x000001C7B5DFF230>
+current_time = 1770686450.8345113
+
+    def _perform_health_check(self, current_time):
+        """Check system health."""
+        health_ok = True
+        reasons = []
+    
+        # 1. MQTT Check
+        if self.mqtt_handler and self.mqtt_handler.health_check_enabled and not self.mqtt_handler.connected:
+            health_ok = False
+            reasons.append("MQTT disconnected")
+    
+        # 2. Connection Lost Watchdog
+        if self.connection_lost_time > 0:
+            if current_time - self.connection_lost_time > 60:
+                logger.error("Connection LOST for >60s. Forcing restart...")
+                import sys
+                sys.exit(1)
+    
+        # 3. Radio Watchdog
+        if self.last_radio_activity > 0:
+            time_since_radio = current_time - self.last_radio_activity
+            if time_since_radio > cfg.health_check_activity_timeout:
+                # Silence...
+                time_since_probe = current_time - self.last_probe_time
+                if time_since_probe > 40:
+                    logger.warning(f"Radio silent for {int(time_since_radio)}s. Sending active probe...")
+                    try:
+                        self.last_probe_time = current_time
+                        if self.iface:
+                             self.iface.sendPosition()
+                    except Exception as e:
+                        logger.warning("Failed to probe: %s", e)
+                elif time_since_probe > 30:
+                     health_ok = False
+                     reasons.append(f"Radio silent (Probed {int(time_since_probe)}s ago - NO REPLY)")
+    
+        # 4. MQTT TX Failures
+>       if self.mqtt_handler and self.mqtt_handler.tx_failures > 5:
+E       TypeError: '>' not supported between instances of 'MagicMock' and 'int'
+
+mqtt-proxy.py:184: TypeError
+_______________________________ test_log_status _______________________________
+
+    def test_log_status():
+        proxy = MQTTProxy()
+        proxy.mqtt_handler = MagicMock()
+        proxy.mqtt_handler.connected = True
+        proxy.last_radio_activity = time.time() - 10
+    
+        # Should not log if interval not reached
+>       proxy._log_status(time.time())
+
+tests\test_proxy_health.py:117: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+self = <mqtt_proxy_test.MQTTProxy object at 0x000001C7B5EB48A0>
+current_time = 1770686450.842585
+
+    def _log_status(self, current_time):
+        if current_time - self.last_status_log_time > cfg.health_check_status_interval:
+            time_since_radio = current_time - self.last_radio_activity if self.last_radio_activity > 0 else -1
+            mqtt_active = self.mqtt_handler.last_activity if self.mqtt_handler else 0
+>           time_since_mqtt = current_time - mqtt_active if mqtt_active > 0 else -1
+E           TypeError: '>' not supported between instances of 'MagicMock' and 'int'
+
+mqtt-proxy.py:194: TypeError
+____________________________ test_update_heartbeat ____________________________
+
+    def test_update_heartbeat():
+        proxy = MQTTProxy()
+    
+        # CASE: Healthy
+        with patch("builtins.open", mock_open()) as mocked_file:
+            proxy._update_heartbeat(time.time(), True, [])
+            mocked_file.assert_called_with("/tmp/healthy", "w")
+    
+        # CASE: Unhealthy (should exit)
+        with patch("sys.exit") as mock_exit:
+            with patch("os.path.exists", return_value=True):
+                with patch("os.remove") as mock_remove:
+                    proxy._update_heartbeat(time.time(), False, ["Test Reason"])
+                    mock_remove.assert_called_with("/tmp/healthy")
+>                   mock_exit.assert_called_with(1)
+
+tests\test_proxy_health.py:139: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+self = <MagicMock name='exit' id='1957262485088'>, args = (1,), kwargs = {}
+expected = 'exit(1)', actual = 'not called.'
+error_message = 'expected call not found.\nExpected: exit(1)\n  Actual: not called.'
+
+    def assert_called_with(self, /, *args, **kwargs):
+        """assert that the last call was made with the specified arguments.
+    
+        Raises an AssertionError if the args and keyword args passed in are
+        different to the last call to the mock."""
+        if self.call_args is None:
+            expected = self._format_mock_call_signature(args, kwargs)
+            actual = 'not called.'
+            error_message = ('expected call not found.\nExpected: %s\n  Actual: %s'
+                    % (expected, actual))
+>           raise AssertionError(error_message)
+E           AssertionError: expected call not found.
+E           Expected: exit(1)
+E             Actual: not called.
+
+C:\Users\dremb\AppData\Local\Python\pythoncore-3.14-64\Lib\unittest\mock.py:976: AssertionError
+------------------------------ Captured log call ------------------------------
+ERROR    mqtt-proxy:mqtt-proxy.py:211 Health check FAILED: Test Reason. Exiting...
+=========================== short test summary info ===========================
+FAILED tests/test_proxy_health.py::test_on_connection_edge_cases - assert <ha...
+FAILED tests/test_proxy_health.py::test_health_check_logic - TypeError: '>' n...
+FAILED tests/test_proxy_health.py::test_log_status - TypeError: '>' not suppo...
+FAILED tests/test_proxy_health.py::test_update_heartbeat - AssertionError: ex...
+========================= 4 failed, 3 passed in 0.43s =========================

--- a/meshtastic_fail.txt
+++ b/meshtastic_fail.txt
@@ -1,0 +1,95 @@
+============================= test session starts =============================
+platform win32 -- Python 3.14.2, pytest-7.4.3, pluggy-1.6.0 -- C:\Users\dremb\AppData\Local\Python\pythoncore-3.14-64\python.exe
+cachedir: .pytest_cache
+rootdir: E:\proj\AiAssited\mqtt-proxy
+plugins: anyio-3.7.1, cov-4.1.0
+collecting ... collected 6 items
+
+tests/test_meshtastic_extended.py::test_handle_from_radio_bytes FAILED   [ 16%]
+tests/test_meshtastic_extended.py::test_handle_from_radio_malformed_bytes PASSED [ 33%]
+tests/test_meshtastic_extended.py::test_implicit_ack_detection FAILED    [ 50%]
+tests/test_meshtastic_extended.py::test_handle_from_radio_super_crash_handling PASSED [ 66%]
+tests/test_meshtastic_extended.py::test_create_interface_serial PASSED   [ 83%]
+tests/test_meshtastic_extended.py::test_create_interface_invalid PASSED  [100%]
+
+================================== FAILURES ===================================
+________________________ test_handle_from_radio_bytes _________________________
+
+    def test_handle_from_radio_bytes():
+        proxy = MockProxy()
+        mixin = TestInterface(proxy)
+    
+        # Create FromRadio bytes
+        from_radio = mesh_pb2.FromRadio()
+        from_radio.mqttClientProxyMessage.topic = "test"
+        from_radio.mqttClientProxyMessage.data = b"abc"
+        from_radio_bytes = from_radio.SerializeToString()
+    
+        # Patch super()._handleFromRadio to avoid AttributeError since TestInterface doesn't have a real parent
+        with patch('handlers.meshtastic.MQTTProxyMixin._handleFromRadio') as _ :
+            # We call the mixin method directly to test its logic
+            MQTTProxyMixin._handleFromRadio(mixin, from_radio_bytes)
+    
+>       proxy.mqtt_handler.publish.assert_called_with("test", b"abc", retain=False)
+
+tests\test_meshtastic_extended.py:38: 
+_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
+
+self = <MagicMock name='mock.publish' id='1580463631936'>
+args = ('test', b'abc'), kwargs = {'retain': False}
+expected = "publish('test', b'abc', retain=False)", actual = 'not called.'
+error_message = "expected call not found.\nExpected: publish('test', b'abc', retain=False)\n  Actual: not called."
+
+    def assert_called_with(self, /, *args, **kwargs):
+        """assert that the last call was made with the specified arguments.
+    
+        Raises an AssertionError if the args and keyword args passed in are
+        different to the last call to the mock."""
+        if self.call_args is None:
+            expected = self._format_mock_call_signature(args, kwargs)
+            actual = 'not called.'
+            error_message = ('expected call not found.\nExpected: %s\n  Actual: %s'
+                    % (expected, actual))
+>           raise AssertionError(error_message)
+E           AssertionError: expected call not found.
+E           Expected: publish('test', b'abc', retain=False)
+E             Actual: not called.
+
+C:\Users\dremb\AppData\Local\Python\pythoncore-3.14-64\Lib\unittest\mock.py:976: AssertionError
+_________________________ test_implicit_ack_detection _________________________
+
+    def test_implicit_ack_detection():
+        proxy = MockProxy()
+        mixin = TestInterface(proxy)
+    
+        from_radio = mesh_pb2.FromRadio()
+        packet = from_radio.packet
+        packet.decoded.portnum = portnums_pb2.ROUTING_APP
+        packet.decoded.request_id = 999
+    
+        routing = mesh_pb2.Routing()
+        routing.error_reason = mesh_pb2.Routing.Error.NONE
+        packet.decoded.payload = routing.SerializeToString()
+    
+        with patch('pubsub.pub.sendMessage') as mock_pub:
+            # DO NOT patch the method we are calling
+            MQTTProxyMixin._handleFromRadio(mixin, from_radio)
+    
+            # Check if meshtastic.ack was sent
+            # We use ANY for interface to avoid mismatch in mock objects vs 'mixin'
+>           mock_pub.assert_any_call("meshtastic.ack", packetId=999, interface=ANY)
+E           NameError: name 'ANY' is not defined
+
+tests\test_meshtastic_extended.py:65: NameError
+------------------------------ Captured log call ------------------------------
+ERROR    mqtt-proxy.handlers.meshtastic:meshtastic.py:112 Error in StreamInterface processing: 'super' object has no attribute '_handleFromRadio'
+============================== warnings summary ===============================
+tests\test_meshtastic_extended.py:14
+  E:\proj\AiAssited\mqtt-proxy\tests\test_meshtastic_extended.py:14: PytestCollectionWarning: cannot collect test class 'TestInterface' because it has a __init__ constructor (from: tests/test_meshtastic_extended.py)
+    class TestInterface(MQTTProxyMixin):
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+=========================== short test summary info ===========================
+FAILED tests/test_meshtastic_extended.py::test_handle_from_radio_bytes - Asse...
+FAILED tests/test_meshtastic_extended.py::test_implicit_ack_detection - NameE...
+=================== 2 failed, 4 passed, 1 warning in 0.33s ====================

--- a/pr_body.md
+++ b/pr_body.md
@@ -1,0 +1,17 @@
+## Overview
+This PR addresses communication failures and health check loopholes encountered after a `meshmonitor` upgrade. The root cause was a race condition where the MQTT handler was initialized before the virtual node provided its configuration, causing the proxy to sit idle while incorrectly reporting as "healthy".
+
+## Key Changes
+- **MQTT Lifecycle**: Centralized MQTT initialization in `_init_mqtt`. Startup is now deferred until **after** `_wait_for_config()` successfully completes, ensuring credentials and root topics are available.
+- **Improved Health Monitoring**:
+    - The health check now detects if a Meshtastic interface is active but the MQTT handler is uninitialized.
+    - Added type safety for telemetry counters to prevent crashes in the watchdog logic.
+- **Robustness**: Moved `os` and `sys` imports to the top level in `mqtt-proxy.py` to ensure consistency and fix related bugs.
+- **Test Suite**:
+    - Resolved `ModuleNotFoundError` in tests by fixing `sys.path`.
+    - Added new test cases to verify the "MQTT handler uninitialized" failure state.
+    - Fixed mocking issues in `test_meshtastic_extended.py`.
+
+## Verification Results
+- 19 automated tests passed (`test_proxy_health.py`, `test_meshtastic_extended.py`, `test_mqtt_proxy.py`).
+- Verified that connection loss during the upgrade triggers the expected watchdog restart.

--- a/test_results.txt
+++ b/test_results.txt
@@ -1,0 +1,59 @@
+============================= test session starts =============================
+platform win32 -- Python 3.14.2, pytest-7.4.3, pluggy-1.6.0 -- C:\Users\dremb\AppData\Local\Python\pythoncore-3.14-64\python.exe
+cachedir: .pytest_cache
+rootdir: E:\proj\AiAssited\mqtt-proxy
+plugins: anyio-3.7.1, cov-4.1.0
+collecting ... collected 10 items
+
+tests/test_mqtt_extended.py::test_mqtt_configure_minimal FAILED          [ 10%]
+tests/test_mqtt_extended.py::test_mqtt_configure_tls FAILED              [ 20%]
+tests/test_mqtt_extended.py::test_mqtt_start_invalid_address PASSED      [ 30%]
+tests/test_mqtt_extended.py::test_mqtt_publish_failure PASSED            [ 40%]
+tests/test_mqtt_extended.py::test_mqtt_on_connect_failure PASSED         [ 50%]
+tests/test_mqtt_extended.py::test_mqtt_on_disconnect_unexpected PASSED   [ 60%]
+tests/test_mqtt_extended.py::test_mqtt_on_message_stat PASSED            [ 70%]
+tests/test_mqtt_extended.py::test_mqtt_on_message_own PASSED             [ 80%]
+tests/test_mqtt_extended.py::test_mqtt_on_message_mesh_packet_fallback PASSED [ 90%]
+tests/test_mqtt_extended.py::test_mqtt_on_message_exception_handling PASSED [100%]
+
+================================== FAILURES ===================================
+_________________________ test_mqtt_configure_minimal _________________________
+
+    def test_mqtt_configure_minimal():
+        config = MagicMock()
+        handler = MQTTHandler(config, "1234abcd")
+    
+        # Minimal config (no address)
+        node_cfg = MagicMock()
+        node_cfg.enabled = True
+        node_cfg.address = None
+    
+        handler.configure(node_cfg)
+        assert handler.mqtt_address is None
+>       assert handler.mqtt_port == 1883
+E       assert 1 == 1883
+E        +  where 1 = <handlers.mqtt.MQTTHandler object at 0x0000019122780980>.mqtt_port
+
+tests\test_mqtt_extended.py:19: AssertionError
+___________________________ test_mqtt_configure_tls ___________________________
+
+    def test_mqtt_configure_tls():
+        config = MagicMock()
+        handler = MQTTHandler(config, "1234abcd")
+    
+        node_cfg = MagicMock()
+        node_cfg.enabled = True
+        node_cfg.address = "mqtt.meshtastic.org"
+        node_cfg.tlsEnabled = True
+    
+        with patch('ssl.create_default_context') as mock_ssl:
+            handler.configure(node_cfg)
+>           assert handler.mqtt_port == 8883
+E           assert 1 == 8883
+E            +  where 1 = <handlers.mqtt.MQTTHandler object at 0x0000019121FCC7D0>.mqtt_port
+
+tests\test_mqtt_extended.py:32: AssertionError
+=========================== short test summary info ===========================
+FAILED tests/test_mqtt_extended.py::test_mqtt_configure_minimal - assert 1 ==...
+FAILED tests/test_mqtt_extended.py::test_mqtt_configure_tls - assert 1 == 8883
+========================= 2 failed, 8 passed in 0.42s =========================


### PR DESCRIPTION
# Release v1.2.0

## 🛡️ Reliability & Stability Improvements

### Thread-Safe Radio Interactions
- **Locked Radio Access**: Implemented thread-safe `_sendToRadio` using the interface's internal locking mechanism.
  - Prevents potential race conditions when multiple handlers attempt to send data to the radio simultaneously.
  - Added fallback with warning if `_sendToRadio` is missing (e.g., in older `meshtastic` library versions).

### Enhanced Packet Management
- **Improved Deduplication**: Refined the deduplication logic to better handle packet IDs and sender tracking.
  - Prevents message loops when proxying traffic between MQTT and the mesh network.

### Robust Health Monitoring
- **Configuration Race Condition Fix**: Addressed a race condition in MQTT handler initialization to ensure reliable startup and state management.
- **Improved Health Checks**: Enhanced watchdog mechanisms for better reporting of proxy status.

## 📊 Performance & Monitoring

### Latency Logging
- **Detailed Message Queue Stats**: Added precise timing logs for message processing.
  - New Log Format: `Message processed. Queue: N msgs, Wait: X.XXXs, Send: X.XXXs`
  - Helps track transit times and identify bottlenecks in radio transmissions.

## 🧪 Test Coverage & CI/CD

### Enhanced Test Suite
- **Queue Handler Coverage**: Increased test coverage for `handlers/queue.py` to ensure reliable buffering and rate limiting.
- **Thread Safety Validation**: Added tests to verify thread-safe usage of the radio interface.

### CI/CD Optimizations
- **Build Trigger Cleanup**: Fixed duplicate Docker image builds by refining push event wildcard triggers.
- **Cleanup Workflow Fix**: Resolved `Invalid Cut-off` errors in image retention policy by updating to properly formatted duration strings (`14d`).

## 🔄 Breaking Changes
None - all changes are backward compatible.

## 📊 Testing Status
All tests passing with improved coverage in core message handling modules.

---

**Full Changelog**: https://github.com/LN4CY/mqtt-proxy/compare/v1.1.2...v1.2.0
