### PR TITLE
chore: bump version to v1.4.1 in release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# Release v1.4.0
+# Release v1.4.1
 
 ## 🐛 Bug Fixes
 


### PR DESCRIPTION
Updating RELEASE_NOTES.md to reflect the successful v1.4.1 release (bypassing GitHub's immutable release rule on v1.4.0).