### PR TITLE
fix: upload exe asset to existing release if tag already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,12 +79,18 @@ jobs:
               f.write(''.join(notes).strip())
           "
 
-      - name: Create Release
+      - name: Create or Update Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Use gh CLI for atomic creation to satisfy "Immutable Release" rules
-          gh release create "$GITHUB_REF_NAME" \
-            --title "$GITHUB_REF_NAME" \
-            --notes-file latest_notes.md \
-            release-assets/mqtt-proxy-windows-amd64.exe
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            echo "Release $GITHUB_REF_NAME already exists. Uploading asset..."
+            gh release upload "$GITHUB_REF_NAME" release-assets/mqtt-proxy-windows-amd64.exe --clobber
+          else
+            echo "Creating new release $GITHUB_REF_NAME..."
+            gh release create "$GITHUB_REF_NAME" \
+              --title "$GITHUB_REF_NAME" \
+              --notes-file latest_notes.md \
+              release-assets/mqtt-proxy-windows-amd64.exe
+          fi


### PR DESCRIPTION
## Problem

When a GitHub Release is created via the Web UI (or the workflow is re-run after a partial failure), the release tag already exists. The release job was calling `gh release create` which fails with an immutability error.

## Fix

Modified the `Create Release` step to:
- Check if the release already exists using `gh release view`
- If it **exists**: use `gh release upload --clobber` to attach the Windows `.exe` asset
- If it **does not exist**: proceed with `gh release create` as before