### PR TITLE
fix: add workflow_dispatch tag_name input

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - "v*.*.*"
   workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Tag name to release (e.g. v1.6.3)'
+        required: true
 
 permissions:
   contents: write
@@ -15,6 +19,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.tag_name || github.ref }}
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -40,10 +46,17 @@ jobs:
   release:
     needs: build-windows-exe
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
     steps:
+      - name: Resolve tag name
+        id: tag
+        run: |
+          TAG="${{ github.event.inputs.tag_name || github.ref_name }}"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
 
       - name: Download Windows Binary
         uses: actions/download-artifact@v4
@@ -56,7 +69,7 @@ jobs:
         run: |
           python3 -c "
           import os
-          version = os.environ.get('GITHUB_REF_NAME', '').replace('v', '')
+          version = '${{ steps.tag.outputs.tag }}'.replace('v', '')
           notes_path = 'RELEASE_NOTES.md'
           if not os.path.exists(notes_path):
               exit(0)
@@ -83,14 +96,14 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Use gh CLI for atomic creation to satisfy "Immutable Release" rules
-          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
-            echo "Release $GITHUB_REF_NAME already exists. Uploading asset..."
-            gh release upload "$GITHUB_REF_NAME" release-assets/mqtt-proxy-windows-amd64.exe --clobber
+          TAG="${{ steps.tag.outputs.tag }}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists. Uploading asset..."
+            gh release upload "$TAG" release-assets/mqtt-proxy-windows-amd64.exe --clobber
           else
-            echo "Creating new release $GITHUB_REF_NAME..."
-            gh release create "$GITHUB_REF_NAME" \
-              --title "$GITHUB_REF_NAME" \
+            echo "Creating new release $TAG..."
+            gh release create "$TAG" \
+              --title "$TAG" \
               --notes-file latest_notes.md \
               release-assets/mqtt-proxy-windows-amd64.exe
           fi


### PR DESCRIPTION
Allows manually triggering the release action from master for an existing tag, so it uses the updated workflow logic.