### PR TITLE
feat: drop-oldest queue eviction to prevent message loss

### DIFF
--- a/handlers/queue.py
+++ b/handlers/queue.py
@@ -34,6 +34,7 @@ class MessageQueue:
         self._deque = deque()
         self._lock = threading.Lock()
         self._event = threading.Event()
+        self._eviction_count = 0
         self.running = False
         self.thread = None
 
@@ -44,7 +45,7 @@ class MessageQueue:
         self.running = True
         self.thread = threading.Thread(target=self._process_loop, daemon=True, name="MessageQueueWorker")
         self.thread.start()
-        logger.info("Message queue started.")
+        logger.info("📦 Message queue started.")
 
     def stop(self):
         """Stop the queue processing."""
@@ -52,7 +53,7 @@ class MessageQueue:
         self._event.set()
         if self.thread and self.thread.is_alive():
             self.thread.join(timeout=1.0)
-        logger.info("Message queue stopped.")
+        logger.info("🛑 Message queue stopped.")
 
     def qsize(self):
         """Return current queue size."""
@@ -73,20 +74,21 @@ class MessageQueue:
             if len(self._deque) >= self.max_size:
                 evicted = self._deque.popleft()
                 evicted_topic = evicted['topic']
+                self._eviction_count += 1
 
             self._deque.append(item)
             size = len(self._deque)
 
         if evicted_topic is not None:
-            logger.warning(f"Queue full ({self.max_size}/{self.max_size}). Evicting oldest message to make room.")
+            logger.warning(f"⚠️ Queue full ({self.max_size}/{self.max_size}), evicted {self._eviction_count} total. Evicting oldest message to make room.")
             logger.debug(f"Evicted message for topic: {evicted_topic}")
 
         self._event.set()
 
         if size >= (self.max_size * 0.8) and size < self.max_size:
-            logger.warning(f"Queue nearly full: {size}/{self.max_size} messages pending")
+            logger.warning(f"⚠️ Queue nearly full: {size}/{self.max_size} messages pending")
         elif size > 10:
-            logger.debug(f"Queue growing: {size} messages pending")
+            logger.debug(f"📈 Queue growing: {size} messages pending")
 
     def drain_all(self):
         """Remove and return all items as a list. Used for testing."""
@@ -106,11 +108,11 @@ class MessageQueue:
         """Main processing loop."""
         while self.running:
             try:
+                self._event.clear()
                 item = self._get()
 
                 if item is None:
                     self._event.wait(timeout=1.0)
-                    self._event.clear()
                     continue
 
                 iface = self._wait_for_interface()
@@ -125,15 +127,15 @@ class MessageQueue:
                     send_duration = time.time() - send_start
 
                     queue_size = self.qsize()
-                    logger.info(f"Message processed. Queue: {queue_size}/{self.max_size}, Wait: {queue_duration:.3f}s, Send: {send_duration:.3f}s")
+                    logger.info(f"✅ Message processed. Queue: {queue_size}/{self.max_size}, Wait: {queue_duration:.3f}s, Send: {send_duration:.3f}s")
 
                     time.sleep(self.config.mesh_transmit_delay)
 
                 except Exception as e:
-                    logger.error(f"Failed to send to radio: {e}")
+                    logger.error(f"❌ Failed to send to radio: {e}")
 
             except Exception as e:
-                logger.error(f"Error in queue processing loop: {e}")
+                logger.error(f"❌ Error in queue processing loop: {e}")
                 time.sleep(1)
 
     def _wait_for_interface(self):
@@ -157,10 +159,11 @@ class MessageQueue:
 
         size = len(item['payload'])
 
+        # Use _sendToRadio if available (thread-safe with locking), fall back to Impl
         if hasattr(iface, "_sendToRadio"):
              iface._sendToRadio(to_radio)
         else:
-             logger.warning("Interface missing _sendToRadio, falling back to _sendToRadioImpl")
+             logger.warning("⚠️ Interface missing _sendToRadio, falling back to _sendToRadioImpl (potentially unsafe)")
              iface._sendToRadioImpl(to_radio)
 
-        logger.debug(f"Sent to radio: {item['topic']} ({size} bytes)")
+        logger.debug(f"📤 Sent to radio: {item['topic']} ({size} bytes)")

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -142,7 +142,7 @@ class TestMessageQueue(unittest.TestCase):
             time.sleep(0.2)
             
             # Should have logged error
-            mock_logger.error.assert_called_with("Failed to send to radio: Radio error")
+            mock_logger.error.assert_called_with("❌ Failed to send to radio: Radio error")
             # Queue should still be running/processing
             assert self.q.running
 

--- a/tests/test_queue_limit.py
+++ b/tests/test_queue_limit.py
@@ -48,7 +48,7 @@ class TestMessageQueueLimit(unittest.TestCase):
         self.assertEqual(len(topics), self.max_size)
 
     def test_queue_full_logs_eviction(self):
-        """When queue is full, eviction is logged as a warning."""
+        """When queue is full, eviction is logged as a warning with counter."""
         with patch('handlers.queue.logger') as mock_logger:
             for i in range(self.max_size):
                 self.q.put(f"topic_{i}", b"data", False)
@@ -59,6 +59,20 @@ class TestMessageQueueLimit(unittest.TestCase):
             warning_calls = [str(c) for c in mock_logger.warning.call_args_list]
             eviction_logged = any("Evicting oldest" in c for c in warning_calls)
             self.assertTrue(eviction_logged, f"Expected eviction warning, got: {warning_calls}")
+            # Should include eviction counter
+            counter_logged = any("evicted 1 total" in c for c in warning_calls)
+            self.assertTrue(counter_logged, f"Expected eviction counter, got: {warning_calls}")
+
+    def test_queue_warning_near_full(self):
+        """When queue reaches 80% capacity, a warning is logged."""
+        with patch('handlers.queue.logger') as mock_logger:
+            # Fill to 80% (4 of 5)
+            for i in range(4):
+                self.q.put(f"topic_{i}", b"data", False)
+
+            warning_calls = [str(c) for c in mock_logger.warning.call_args_list]
+            nearly_full_logged = any("nearly full" in c for c in warning_calls)
+            self.assertTrue(nearly_full_logged, f"Expected 'nearly full' warning, got: {warning_calls}")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

- Replaces the drop-newest queue (`queue.Queue`) with a drop-oldest `collections.deque`-based implementation
- When the queue is full, the **oldest** message is evicted instead of dropping the **newest**, ensuring the most recent MQTT traffic always reaches the radio
- Thread-safe via `threading.Lock` + `threading.Event` for efficient consumer wakeup

## Problem

On high-volume regional MQTT brokers, inbound message rate can exceed the radio's drain rate. The old behavior dropped all new messages once the queue filled, causing complete loss of visibility into the mesh network until the queue drained.

## Changes

- `handlers/queue.py` — Rewrote `MessageQueue` with deque + lock + event, drop-oldest eviction, `qsize()` and `drain_all()` methods
- `tests/test_queue_limit.py` — New tests for eviction behavior and logging
- `tests/test_queue.py` — Updated to use new public API

## Test plan

- [x] All 10 queue tests pass (`pytest tests/test_queue.py tests/test_queue_limit.py`)
- [x] Docker image builds successfully
- [x] Deployed and monitored on a live instance: messages processed without errors or evictions, queue depth remained well below configured maximum