### PR TITLE
Fix: Harden Docker Tagging, Cleanup, and Standardize Documentation

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -15,8 +15,8 @@ jobs:
         uses: snok/container-retention-policy@v3.0.0
         with:
           image-names: mqtt-proxy
-          cut-off: 14d
-          account: user
+          cut-off: 90d
+          account: ${{ github.repository_owner }}
           token: ${{ secrets.GITHUB_TOKEN }}
           tag-selection: untagged
 
@@ -24,19 +24,19 @@ jobs:
         uses: snok/container-retention-policy@v3.0.0
         with:
           image-names: mqtt-proxy
-          cut-off: 14d
-          account: user
+          cut-off: 90d
+          account: ${{ github.repository_owner }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          image-tags: fix-*,feat-*,pr-*
+          image-tags: "!v*,!latest,fix-*,feat-*,pr-*"
           keep-n-most-recent: 3
 
       - name: Delete old master branch images
         uses: snok/container-retention-policy@v3.0.0
         with:
           image-names: mqtt-proxy
-          cut-off: 30d
-          account: user
+          cut-off: 90d
+          account: ${{ github.repository_owner }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          image-tags: master
+          image-tags: "!v*,!latest,master"
           keep-n-most-recent: 5
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,6 +7,7 @@ on:
     tags: [ 'v*.*.*' ]
   pull_request:
     branches: [ "master", "main" ]
+  workflow_dispatch:      # Allow manual re-triggering to restore missing images
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -59,7 +60,7 @@ jobs:
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern=latest
             type=sha,format=long
 
       # Build and push Docker image with Buildx (don't push on PR)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ docker run -d \
   -e INTERFACE_TYPE=tcp \
   -e TCP_NODE_HOST=192.168.1.100 \
   -e TCP_NODE_PORT=4403 \
-  ghcr.io/ln4cy/mqtt-proxy:master
+  ghcr.io/ln4cy/mqtt-proxy:latest
 ```
 
 ## Configuration
@@ -261,6 +261,20 @@ Docker Desktop for Mac 4.27+ supports USB device forwarding:
 3. Device appears as `/dev/ttyACM0` in containers
 4. Update `docker-compose.yml` devices section accordingly
 
+## Docker Images & Tag Policy
+
+We maintain multiple tags for the `ghcr.io/ln4cy/mqtt-proxy` image to suit different needs:
+
+| Tag | Description | Recommended For |
+|-----|-------------|-----------------|
+| `:latest` | The most recent stable release (SemVer tagged). | Production / General Use |
+| `:vX.Y.Z` | A specific stable release version. | Version pinning |
+| `:master` | The latest development build from the `master` branch. | Testing new features |
+| `:sha-<hash>` | Build linked to a specific git commit. | CI/CD automation |
+
+> [!TIP]
+> **Production Recommendation**: Most users should pull the `:latest` tag to ensure they have the most recent stable features and security fixes.
+
 ## Integration with MeshMonitor
 
 For a seamless integration with [MeshMonitor](https://github.com/Yeraze/meshmonitor), add the proxy as a service in your main `docker-compose.yml`.
@@ -324,7 +338,7 @@ services:
 
   # This proxy service (The Glue)
   mqtt-proxy:
-    image: ghcr.io/ln4cy/mqtt-proxy:master
+    image: ghcr.io/ln4cy/mqtt-proxy:latest
     container_name: mqtt-proxy
     restart: unless-stopped
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     # Build from source
     build: .
     # OR use pre-built image
-    # image: ghcr.io/ln4cy/mqtt-proxy:master
+    # image: ghcr.io/ln4cy/mqtt-proxy:latest
     container_name: mqtt-proxy
     restart: unless-stopped
     environment:


### PR DESCRIPTION
## Summary
This PR addresses the \manifest unknown\ issue reported in #53 by hardening the CI/CD workflows and standardizing the image tagging policy in the documentation.

## Changes
- **CI/CD**: Added \workflow_dispatch\ to \docker-publish.yml\ and used \	ype=semver,pattern=latest\ for more robust tagging.
- **Cleanup**: Updated \cleanup-images.yml\ to explicitly exclude \*\ and \latest\ tags from deletion and increased the \cut-off\ to 90 days.
- **Documentation**: Standardized all examples in \README.md\ and \docker-compose.yml\ to use the \:latest\ tag and added a clear Docker Tag Policy section.

Closes #53