### PR TITLE
CI: Add Manual Restore Inputs for Docker Images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,6 +8,15 @@ on:
   pull_request:
     branches: [ "master", "main" ]
   workflow_dispatch:      # Allow manual re-triggering to restore missing images
+    inputs:
+      version_override:
+        description: 'Force a specific version tag (e.g., 1.6.5)'
+        required: false
+        type: string
+      tag_as_latest:
+        description: 'Also tag this build as latest'
+        type: boolean
+        default: false
 
 env:
   # Use docker.io for Docker Hub if empty
@@ -61,6 +70,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern=latest
+            type=raw,value=${{ github.event.inputs.version_override }},enable=${{ github.event.inputs.version_override != '' }}
+            type=raw,value=latest,enable=${{ github.event.inputs.tag_as_latest == 'true' }}
             type=sha,format=long
 
       # Build and push Docker image with Buildx (don't push on PR)


### PR DESCRIPTION
This PR adds \ersion_override\ and \	ag_as_latest\ inputs to the Docker \workflow_dispatch\ trigger. 

This allows manual restoration of old tags (like 1.6.5) and the stable 'latest' tag directly from the master branch, since old tags do not have the manual trigger capability.