### PR TITLE
ci: bump container-retention-policy to @v3 to fix panic on missing packages

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -12,7 +12,7 @@ jobs:
       packages: write
     steps:
       - name: Delete untagged images
-        uses: snok/container-retention-policy@v3.0.0
+        uses: snok/container-retention-policy@v3
         with:
           image-names: mqtt-proxy
           cut-off: 90d
@@ -21,7 +21,7 @@ jobs:
           tag-selection: untagged
 
       - name: Delete old feature branch images
-        uses: snok/container-retention-policy@v3.0.0
+        uses: snok/container-retention-policy@v3
         with:
           image-names: mqtt-proxy
           cut-off: 90d
@@ -31,7 +31,7 @@ jobs:
           keep-n-most-recent: 3
 
       - name: Delete old master branch images
-        uses: snok/container-retention-policy@v3.0.0
+        uses: snok/container-retention-policy@v3
         with:
           image-names: mqtt-proxy
           cut-off: 90d


### PR DESCRIPTION
## Summary
- Bumps all three `snok/container-retention-policy` steps from `@v3.0.0` to `@v3`
- `v3.0.0` panics with `missing field 'id'` when the GitHub API returns an unexpected response (e.g. the package doesn't exist yet in GHCR)
- `@v3` tracks the latest 3.x patch which handles this case gracefully

## Test plan
- [ ] Merge and manually trigger the Cleanup Old Images workflow to confirm it runs without panicking

🤖 Generated with [Claude Code](https://claude.com/claude-code)