### PR TITLE
ci: fix cleanup action breaking multi-arch images

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -11,23 +11,25 @@ jobs:
     permissions:
       packages: write
     steps:
-      - name: Delete untagged images
+      # Delete commit-SHA images first (generated on every push by type=sha,format=long)
+      # Guard !*.* and !latest prevents touching release or latest tags on the same digest
+      - name: Delete old commit SHA images
         uses: snok/container-retention-policy@v3
         with:
           image-names: mqtt-proxy
-          cut-off: 90d
+          cut-off: 30d
           account: ${{ github.repository_owner }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag-selection: untagged
+          image-tags: "sha-*,!*.*,!latest"
 
-      - name: Delete old feature branch images
+      - name: Delete old feature/PR branch images
         uses: snok/container-retention-policy@v3
         with:
           image-names: mqtt-proxy
           cut-off: 90d
           account: ${{ github.repository_owner }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          image-tags: "!v*,!latest,fix-*,feat-*,pr-*"
+          image-tags: "fix-*,feat-*,pr-*,!*.*,!latest"
           keep-n-most-recent: 3
 
       - name: Delete old master branch images
@@ -37,6 +39,44 @@ jobs:
           cut-off: 90d
           account: ${{ github.repository_owner }}
           token: ${{ secrets.GITHUB_TOKEN }}
-          image-tags: "!v*,!latest,master"
+          image-tags: "master,!*.*,!latest"
           keep-n-most-recent: 5
 
+      # After deleting old tagged images above, collect the platform manifest digests
+      # still referenced by any remaining tagged image, so we don't break multi-arch pulls.
+      - name: Collect platform manifest SHAs to protect
+        id: protected
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAGGED=$(gh api "user/packages/container/mqtt-proxy/versions" \
+            --paginate \
+            --jq '.[] | select(.metadata.container.tags | length > 0) | .name' \
+            2>/dev/null || echo "")
+
+          SKIP=""
+          while IFS= read -r digest; do
+            [ -z "$digest" ] && continue
+            children=$(curl -sf \
+              -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Accept: application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json" \
+              "https://ghcr.io/v2/${{ github.repository_owner }}/mqtt-proxy/manifests/$digest" \
+              | python3 -c "import sys,json; d=json.load(sys.stdin); [print(m['digest']) for m in d.get('manifests',[])]" \
+              2>/dev/null || true)
+            [ -n "$children" ] && SKIP+="${children}"$'\n'
+          done <<< "$TAGGED"
+
+          SKIP_CSV=$(echo "$SKIP" | grep -v '^$' | sort -u | paste -sd,)
+          echo "shas=$SKIP_CSV" >> $GITHUB_OUTPUT
+
+      # Now safe to delete untagged images — orphaned platform manifests from deleted
+      # tagged images above will be cleaned up; active ones are protected via skip-shas.
+      - name: Delete old untagged images
+        uses: snok/container-retention-policy@v3
+        with:
+          image-names: mqtt-proxy
+          cut-off: 30d
+          account: ${{ github.repository_owner }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag-selection: untagged
+          skip-shas: ${{ steps.protected.outputs.shas }}


### PR DESCRIPTION
## Summary

Three bugs in the previous `cleanup-images.yml` were causing tagged images to be deleted or broken:

- **Multi-arch platform manifests being deleted** — `tag-selection: untagged` was deleting the per-platform manifests (amd64/arm64/armv7) that are referenced by tagged index manifests but appear untagged in GHCR. Fix: run a step first to collect those digests, then pass them as `skip-shas` to the untagged cleanup.

- **`!v*` guard didn't protect release tags** — this project emits semver tags as `1.6.5` (no `v` prefix), so `!v*` was a no-op. Fix: use `!*.*` to exclude any tag containing a dot.

- **`sha-*` commit tags never cleaned up** — `type=sha,format=long` generates one tag per push; there was no step targeting these. Fix: new step with 30-day cut-off.

## Step ordering

Tagged cleanup runs first → orphaned platform manifests from just-deleted images are then caught by the untagged step in the same daily run (no 1-day lag).

## Test plan
- [ ] Merge and manually trigger `Cleanup Old Images` workflow
- [ ] Confirm `1.6.5` and `latest` images still pull correctly after cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)