### PR TITLE
ci: pin container-retention-policy to v3.0.1

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -12,7 +12,7 @@ jobs:
       packages: write
     steps:
       - name: Delete untagged images
-        uses: snok/container-retention-policy@v3
+        uses: snok/container-retention-policy@v3.0.1
         with:
           image-names: mqtt-proxy
           cut-off: 90d
@@ -21,7 +21,7 @@ jobs:
           tag-selection: untagged
 
       - name: Delete old feature branch images
-        uses: snok/container-retention-policy@v3
+        uses: snok/container-retention-policy@v3.0.1
         with:
           image-names: mqtt-proxy
           cut-off: 90d
@@ -31,7 +31,7 @@ jobs:
           keep-n-most-recent: 3
 
       - name: Delete old master branch images
-        uses: snok/container-retention-policy@v3
+        uses: snok/container-retention-policy@v3.0.1
         with:
           image-names: mqtt-proxy
           cut-off: 90d


### PR DESCRIPTION
## Summary
- Fixes the broken `@v3` reference introduced in #56 — no floating `v3` tag exists in that repo, only explicit versions like `v3.0.1`
- `v3.0.1` is the latest release (2025-09-23)

Note: PR #57 supersedes this with a more complete fix (multi-arch safe cleanup). Merge whichever lands first; they don't conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)