### PR TITLE
ci: fix cleanup account for personal GitHub account

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           image-names: mqtt-proxy
           cut-off: 30d
-          account: ${{ github.repository_owner }}
+          account: user
           token: ${{ secrets.GITHUB_TOKEN }}
           image-tags: "sha-*,!*.*,!latest"
 
@@ -27,7 +27,7 @@ jobs:
         with:
           image-names: mqtt-proxy
           cut-off: 90d
-          account: ${{ github.repository_owner }}
+          account: user
           token: ${{ secrets.GITHUB_TOKEN }}
           image-tags: "fix-*,feat-*,pr-*,!*.*,!latest"
           keep-n-most-recent: 3
@@ -37,7 +37,7 @@ jobs:
         with:
           image-names: mqtt-proxy
           cut-off: 90d
-          account: ${{ github.repository_owner }}
+          account: user
           token: ${{ secrets.GITHUB_TOKEN }}
           image-tags: "master,!*.*,!latest"
           keep-n-most-recent: 5
@@ -76,7 +76,7 @@ jobs:
         with:
           image-names: mqtt-proxy
           cut-off: 30d
-          account: ${{ github.repository_owner }}
+          account: user
           token: ${{ secrets.GITHUB_TOKEN }}
           tag-selection: untagged
           skip-shas: ${{ steps.protected.outputs.shas }}


### PR DESCRIPTION
## Root cause

`snok/container-retention-policy` parses the `account` input like this:
- Literal string `"user"` → calls `/user/packages/...` (personal account API)
- Anything else → treats it as an org name → calls `/orgs/{value}/packages/...`

We were passing `account: ${{ github.repository_owner }}` which resolves to `"LN4CY"`. Since that's not the literal `"user"`, the action called `/orgs/LN4CY/packages/...` — which 404s because LN4CY is a personal account, not an org. The action then tried to parse the 404 error body as a package list and panicked with `missing field 'id'`.

## Fix
Change all four `account:` values to the literal `user`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)