### PR TITLE
ci: reduce feature/PR image cut-off from 90d to 14d

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -26,7 +26,7 @@ jobs:
         uses: snok/container-retention-policy@v3.0.1
         with:
           image-names: mqtt-proxy
-          cut-off: 90d
+          cut-off: 14d
           account: user
           token: ${{ secrets.GITHUB_TOKEN }}
           image-tags: "fix-*,feat-*,pr-*,!*.*,!latest"


### PR DESCRIPTION
## Summary
- Changes the cut-off for feature/PR branch images from `90d` to `14d`
- The previous 90d cut-off was protecting all existing PR images from deletion since they were all newer than 90 days
- 14 days is enough buffer after a PR is merged/closed; `keep-n-most-recent: 3` still acts as a safety net

🤖 Generated with [Claude Code](https://claude.com/claude-code)