### PR TITLE
ci: split feature/PR cleanup into one step per tag pattern

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -22,14 +22,34 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           image-tags: "sha-*,!*.*,!latest"
 
-      - name: Delete old feature/PR branch images
+      - name: Delete old PR images
         uses: snok/container-retention-policy@v3.0.1
         with:
           image-names: mqtt-proxy
           cut-off: 14d
           account: user
           token: ${{ secrets.GITHUB_TOKEN }}
-          image-tags: "fix-*,feat-*,pr-*,!*.*,!latest"
+          image-tags: "pr-*,!*.*,!latest"
+          keep-n-most-recent: 3
+
+      - name: Delete old fix branch images
+        uses: snok/container-retention-policy@v3.0.1
+        with:
+          image-names: mqtt-proxy
+          cut-off: 14d
+          account: user
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-tags: "fix-*,!*.*,!latest"
+          keep-n-most-recent: 3
+
+      - name: Delete old feat branch images
+        uses: snok/container-retention-policy@v3.0.1
+        with:
+          image-names: mqtt-proxy
+          cut-off: 14d
+          account: user
+          token: ${{ secrets.GITHUB_TOKEN }}
+          image-tags: "feat-*,!*.*,!latest"
           keep-n-most-recent: 3
 
       - name: Delete old master branch images


### PR DESCRIPTION
## Root cause

`snok/container-retention-policy` uses AND logic for tag patterns — an image must match **all** positive patterns to be selected. `fix-*,feat-*,pr-*` in a single step required an image to have tags matching all three simultaneously, which is impossible. Every PR/feature image got the warning "matched some, but not all tags" and was skipped.

## Fix

Split into three separate steps (`pr-*`, `fix-*`, `feat-*`), each with the same `cut-off: 14d` and `keep-n-most-recent: 3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)