### PR TITLE
ci: add sha-* to tag filters so all tags on each image version match

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -29,7 +29,7 @@ jobs:
           cut-off: 14d
           account: user
           token: ${{ secrets.GITHUB_TOKEN }}
-          image-tags: "pr-*,!*.*,!latest"
+          image-tags: "pr-*,sha-*,!*.*,!latest"
           keep-n-most-recent: 3
 
       - name: Delete old fix branch images
@@ -39,7 +39,7 @@ jobs:
           cut-off: 14d
           account: user
           token: ${{ secrets.GITHUB_TOKEN }}
-          image-tags: "fix-*,!*.*,!latest"
+          image-tags: "fix-*,sha-*,!*.*,!latest"
           keep-n-most-recent: 3
 
       - name: Delete old feat branch images
@@ -49,7 +49,7 @@ jobs:
           cut-off: 14d
           account: user
           token: ${{ secrets.GITHUB_TOKEN }}
-          image-tags: "feat-*,!*.*,!latest"
+          image-tags: "feat-*,sha-*,!*.*,!latest"
           keep-n-most-recent: 3
 
       - name: Delete old master branch images
@@ -59,7 +59,7 @@ jobs:
           cut-off: 90d
           account: user
           token: ${{ secrets.GITHUB_TOKEN }}
-          image-tags: "master,!*.*,!latest"
+          image-tags: "master,sha-*,!*.*,!latest"
           keep-n-most-recent: 5
 
       # After deleting old tagged images above, collect the platform manifest digests


### PR DESCRIPTION
## Root cause

`snok/container-retention-policy` requires **every tag** on a package version to match at least one positive pattern (AND across tags, not OR). PR/branch images have two tags per version — e.g. `["sha-abc...", "pr-52"]`. With filter `pr-*`, `sha-abc...` has no matching pattern, so the image gets a "matched some, but not all tags" warning and is skipped.

## Fix

Add `sha-*` to every positive tag filter. The Docker workflow always attaches a `sha-*` tag alongside branch/PR tags, so `sha-*` covers the sha tag on every build image. Applied to all four branch/PR steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)