### PR TITLE
Allow PKI channel uplink so DMs and traceroutes reach MQTT.

### DIFF
--- a/CONFIG.md
+++ b/CONFIG.md
@@ -94,6 +94,7 @@ BLE support requires custom implementation using the `bleak` library. See the [m
 | `POLL_INTERVAL` | integer | `1` | Config polling interval (seconds) |
 | `EXTRA_MQTT_ROOTS` | string | `""` | Comma-separated list of roots with optional prefixes for Virtual Channels (e.g. `msh/US/OH:OH, msh/US/CA:CA`) |
 | `MESH_ALLOW_UNCONFIGURED_CHANNELS` | boolean | `true` | Forward MQTT messages to the radio even if their channel is not explicitly configured on the physical node (Virtual Channel Passthrough). Set to `false` for strict filtering. |
+| `MESH_ALLOW_PKI_UPLINK` | boolean | `true` | Allow Node→MQTT publish for topic channel `PKI` (encrypted DMs / traceroutes). PKI is not a radio channel slot, so without this those uplinks are dropped by the unknown-channel loop-prevention path. |
 
 
 ### Health Check Settings
@@ -206,6 +207,8 @@ The proxy automatically respects your node's channel settings for MQTT filtering
 For each configured channel on your node:
 - If `uplink_enabled` is **false**, the proxy will drop messages received from the mesh on that channel instead of sending them to the MQTT broker.
 - If `downlink_enabled` is **false**, the proxy will ignore messages received from the MQTT broker destined for that channel instead of transmitting them to the mesh.
+
+**PKI / direct messages:** Topic channel `PKI` is never present in `localNode.channels`. With `MESH_ALLOW_PKI_UPLINK=true` (default), the proxy still uplinks those envelopes so DMs and traceroutes reach the public broker. Unknown *other* channels remain dropped on uplink to prevent virtual-channel echo loops.
 
 You can configure these settings using the Meshtastic CLI:
 ```bash

--- a/CONFIG.md
+++ b/CONFIG.md
@@ -208,7 +208,7 @@ For each configured channel on your node:
 - If `uplink_enabled` is **false**, the proxy will drop messages received from the mesh on that channel instead of sending them to the MQTT broker.
 - If `downlink_enabled` is **false**, the proxy will ignore messages received from the MQTT broker destined for that channel instead of transmitting them to the mesh.
 
-**PKI / direct messages:** Topic channel `PKI` is never present in `localNode.channels`. With `MESH_ALLOW_PKI_UPLINK=true` (default), the proxy still uplinks those envelopes so DMs and traceroutes reach the public broker. Unknown *other* channels remain dropped on uplink to prevent virtual-channel echo loops.
+**PKI / direct messages:** Topic channel `PKI` is never present in `localNode.channels`. With `MESH_ALLOW_PKI_UPLINK=true` (default), the proxy still uplinks those envelopes so DMs and traceroutes reach the configured MQTT broker. Unknown *other* channels remain dropped on uplink to prevent virtual-channel echo loops.
 
 You can configure these settings using the Meshtastic CLI:
 ```bash

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ SERIAL_PORT=/dev/ttyACM0
 | `POLL_INTERVAL` | `1` | Config polling interval (seconds) |
 | `MESH_TRANSMIT_DELAY` | `0.5` | Delay between packets for rate limiting (seconds) |
 | `MESH_ALLOW_UNCONFIGURED_CHANNELS` | `true` | Allow forwarding messages for unconfigured channels |
+| `MESH_ALLOW_PKI_UPLINK` | `true` | Allow Node→MQTT publish for topic channel `PKI` (DMs/traceroutes). PKI is not a radio channel slot, so without this those uplinks are dropped by loop-prevention. |
 
 See [CONFIG.md](CONFIG.md) for detailed configuration options.
 

--- a/config.py
+++ b/config.py
@@ -65,6 +65,11 @@ class Config:
         # Max number of messages to keep in queue before dropping new ones
         self.mesh_max_queue_size = int(os.environ.get("MESH_MAX_QUEUE_SIZE", "5000"))  
         
+        # Allow uplink of PKI (direct messages / traceroutes). PKI is not a radio
+        # channel slot, so it never appears in localNode.channels — without this,
+        # Node->MQTT PKI publishes are always dropped (loop-prevention path).
+        self.mesh_allow_pki_uplink = os.environ.get("MESH_ALLOW_PKI_UPLINK", "true").lower() == "true"
+        
         # Allow forwarding messages to/from channels not explicitly configured on the node
         # Default True to maintain backward compatibility (Virtual Channel Passthrough)
         self.mesh_allow_unconfigured_channels = os.environ.get("MESH_ALLOW_UNCONFIGURED_CHANNELS", "true").lower() == "true"

--- a/mqtt-proxy.py
+++ b/mqtt-proxy.py
@@ -55,6 +55,8 @@ class MQTTProxy:
 
     def start(self):
         logger.info("🚀 MQTT Proxy v%s starting (interface: %s)...", __version__, cfg.interface_type.upper())
+        if not getattr(cfg, "mesh_allow_pki_uplink", True):
+            logger.info("🛡️ PKI uplink disabled (MESH_ALLOW_PKI_UPLINK=false)")
 
         # Subscribe to events
         pub.subscribe(self.on_connection, "meshtastic.connection.established")
@@ -259,13 +261,8 @@ class MQTTProxy:
         # PKI is the MQTT topic for encrypted DMs/traceroutes — not a channel index.
         # Allow publishing those to the broker (default on; disable via MESH_ALLOW_PKI_UPLINK=false).
         if search_name == "pki":
-            allow = getattr(cfg, "mesh_allow_pki_uplink", True)
-            if allow:
-                logger.debug("📡 PKI uplink allowed (MESH_ALLOW_PKI_UPLINK)")
-            else:
-                logger.info("🛡️ PKI uplink disabled (MESH_ALLOW_PKI_UPLINK=false)")
-            return allow
-        
+            return getattr(cfg, "mesh_allow_pki_uplink", True)
+
         for i, ch in enumerate(self.iface.localNode.channels):
             if ch.role == 0: continue
             

--- a/mqtt-proxy.py
+++ b/mqtt-proxy.py
@@ -255,6 +255,16 @@ class MQTTProxy:
             return True
             
         search_name = channel_name.lower()
+
+        # PKI is the MQTT topic for encrypted DMs/traceroutes — not a channel index.
+        # Allow publishing those to the broker (default on; disable via MESH_ALLOW_PKI_UPLINK=false).
+        if search_name == "pki":
+            allow = getattr(cfg, "mesh_allow_pki_uplink", True)
+            if allow:
+                logger.debug("📡 PKI uplink allowed (MESH_ALLOW_PKI_UPLINK)")
+            else:
+                logger.info("🛡️ PKI uplink disabled (MESH_ALLOW_PKI_UPLINK=false)")
+            return allow
         
         for i, ch in enumerate(self.iface.localNode.channels):
             if ch.role == 0: continue

--- a/tests/test_channel_filtering.py
+++ b/tests/test_channel_filtering.py
@@ -121,7 +121,9 @@ class TestChannelFiltering:
         # Uplink MUST BE DROPPED by default to prevent infinite echo loops
         assert proxy._is_channel_uplink_enabled("Unknown") == False
 
-    def test_pki_uplink_allowed_by_default(self):
+    def test_pki_uplink_allowed_by_default(self, monkeypatch):
+        import config as cfgmod
+        monkeypatch.setattr(cfgmod.cfg, "mesh_allow_pki_uplink", True)
         proxy = MQTTProxy()
         proxy.iface = MagicMock()
         proxy.iface.localNode.channels = []

--- a/tests/test_channel_filtering.py
+++ b/tests/test_channel_filtering.py
@@ -121,7 +121,7 @@ class TestChannelFiltering:
         # Uplink MUST BE DROPPED by default to prevent infinite echo loops
         assert proxy._is_channel_uplink_enabled("Unknown") == False
 
-    def test_pki_uplink_allowed_by_default(self, monkeypatch):
+    def test_pki_uplink_allowed_when_enabled(self, monkeypatch):
         import config as cfgmod
         monkeypatch.setattr(cfgmod.cfg, "mesh_allow_pki_uplink", True)
         proxy = MQTTProxy()

--- a/tests/test_channel_filtering.py
+++ b/tests/test_channel_filtering.py
@@ -120,3 +120,18 @@ class TestChannelFiltering:
         assert proxy._is_channel_downlink_enabled("Unknown") == True
         # Uplink MUST BE DROPPED by default to prevent infinite echo loops
         assert proxy._is_channel_uplink_enabled("Unknown") == False
+
+    def test_pki_uplink_allowed_by_default(self):
+        proxy = MQTTProxy()
+        proxy.iface = MagicMock()
+        proxy.iface.localNode.channels = []
+        assert proxy._is_channel_uplink_enabled("PKI") == True
+        assert proxy._is_channel_uplink_enabled("pki") == True
+
+    def test_pki_uplink_can_be_disabled(self, monkeypatch):
+        import config as cfgmod
+        monkeypatch.setattr(cfgmod.cfg, "mesh_allow_pki_uplink", False)
+        proxy = MQTTProxy()
+        proxy.iface = MagicMock()
+        proxy.iface.localNode.channels = []
+        assert proxy._is_channel_uplink_enabled("PKI") == False


### PR DESCRIPTION
PKI is not a radio channel slot, so the unknown-channel loop filter was dropping Node->MQTT publishes; gate via MESH_ALLOW_PKI_UPLINK (default true).